### PR TITLE
Add net9 multi-targeting for ShareX compatibility

### DIFF
--- a/src/ShareX.ImageEditor.Loader/ShareX.ImageEditor.Loader.csproj
+++ b/src/ShareX.ImageEditor.Loader/ShareX.ImageEditor.Loader.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net10.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.19041.0</TargetFramework>
     <Nullable>enable</Nullable>
     <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
     <ApplicationManifest>app.manifest</ApplicationManifest>

--- a/src/ShareX.ImageEditor/ShareX.ImageEditor.csproj
+++ b/src/ShareX.ImageEditor/ShareX.ImageEditor.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net10.0;net10.0-windows10.0.19041.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net9.0-windows10.0.19041.0;net10.0;net10.0-windows10.0.19041.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>


### PR DESCRIPTION
This pull request updates the target frameworks in the project files to improve compatibility and support for different .NET versions and Windows SDKs.

**Target framework updates:**

* Added support for .NET 9.0 and .NET 9.0 with Windows 10.0.19041.0 SDK in the `ShareX.ImageEditor` project by updating the `TargetFrameworks` property.
* Updated the `TargetFramework` in the `ShareX.ImageEditor.Loader` project to explicitly require Windows 10.0.19041.0 SDK for .NET 10.0.