### PR TITLE
Fix rendering and dragging of step arrow tail

### DIFF
--- a/src/ShareX.ImageEditor/Core/Annotations/Text/NumberAnnotation.cs
+++ b/src/ShareX.ImageEditor/Core/Annotations/Text/NumberAnnotation.cs
@@ -296,6 +296,11 @@ public partial class NumberAnnotation : Annotation
         shaftEndRight = default;
         shaftStartRight = default;
 
+        if (!HasTailPoint)
+        {
+            return false;
+        }
+
         float radius = Radius;
         if (radius <= GeometryEpsilon)
         {

--- a/src/ShareX.ImageEditor/Core/Annotations/Text/NumberAnnotation.cs
+++ b/src/ShareX.ImageEditor/Core/Annotations/Text/NumberAnnotation.cs
@@ -109,21 +109,42 @@ public partial class NumberAnnotation : Annotation
 
     public bool IsTailVisible()
     {
-        return TryGetTailPolygon(out _, out _, out _);
+        return TailStyle switch
+        {
+            StepTailStyle.Arrow => TryGetArrowTailOutline(out _, out _, out _, out _, out _, out _, out _),
+            _ => TryGetTailPolygon(out _, out _, out _)
+        };
     }
 
     public SKRect GetInteractionBounds(float tolerance = 0)
     {
         var interactionBounds = GetBounds();
 
-        if (TryGetTailPolygon(out var tailBaseStart, out var tailTip, out var tailBaseEnd))
+        if (TailStyle == StepTailStyle.Arrow)
         {
-            var tailBounds = new SKRect(
-                MathF.Min(tailBaseStart.X, MathF.Min(tailTip.X, tailBaseEnd.X)),
-                MathF.Min(tailBaseStart.Y, MathF.Min(tailTip.Y, tailBaseEnd.Y)),
-                MathF.Max(tailBaseStart.X, MathF.Max(tailTip.X, tailBaseEnd.X)),
-                MathF.Max(tailBaseStart.Y, MathF.Max(tailTip.Y, tailBaseEnd.Y)));
-            interactionBounds = SKRect.Union(interactionBounds, tailBounds);
+            if (TryGetArrowTailOutline(
+                out var shaftStartLeft,
+                out var shaftEndLeft,
+                out var wingLeft,
+                out var tailTip,
+                out var wingRight,
+                out var shaftEndRight,
+                out var shaftStartRight))
+            {
+                interactionBounds = UnionPoints(
+                    interactionBounds,
+                    shaftStartLeft,
+                    shaftEndLeft,
+                    wingLeft,
+                    tailTip,
+                    wingRight,
+                    shaftEndRight,
+                    shaftStartRight);
+            }
+        }
+        else if (TryGetTailPolygon(out var tailBaseStart, out var tailTip, out var tailBaseEnd))
+        {
+            interactionBounds = UnionPoints(interactionBounds, tailBaseStart, tailTip, tailBaseEnd);
         }
 
         if (tolerance > 0)
@@ -191,18 +212,61 @@ public partial class NumberAnnotation : Annotation
             return true;
         }
 
-        if (!TryGetTailPolygon(out var tailBaseStart, out var tailTip, out var tailBaseEnd))
+        if (TailStyle == StepTailStyle.Arrow)
+        {
+            if (!TryGetArrowTailOutline(
+                out var shaftStartLeft,
+                out var shaftEndLeft,
+                out var wingLeft,
+                out var tailTip,
+                out var wingRight,
+                out var shaftEndRight,
+                out var shaftStartRight))
+            {
+                return false;
+            }
+
+            SKPoint[] polygon =
+            [
+                shaftStartLeft,
+                shaftEndLeft,
+                wingLeft,
+                tailTip,
+                wingRight,
+                shaftEndRight,
+                shaftStartRight
+            ];
+
+            if (PointInPolygon(point, polygon))
+            {
+                return true;
+            }
+
+            for (int i = 0; i < polygon.Length; i++)
+            {
+                var segmentStart = polygon[i];
+                var segmentEnd = polygon[(i + 1) % polygon.Length];
+                if (DistanceToSegment(point, segmentStart, segmentEnd) <= tolerance)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        if (!TryGetTailPolygon(out var tailBaseStart, out var triangleTailTip, out var tailBaseEnd))
         {
             return false;
         }
 
-        if (PointInTriangle(point, tailBaseStart, tailTip, tailBaseEnd))
+        if (PointInTriangle(point, tailBaseStart, triangleTailTip, tailBaseEnd))
         {
             return true;
         }
 
-        return DistanceToSegment(point, tailBaseStart, tailTip) <= tolerance ||
-               DistanceToSegment(point, tailTip, tailBaseEnd) <= tolerance ||
+        return DistanceToSegment(point, tailBaseStart, triangleTailTip) <= tolerance ||
+               DistanceToSegment(point, triangleTailTip, tailBaseEnd) <= tolerance ||
                DistanceToSegment(point, tailBaseEnd, tailBaseStart) <= tolerance;
     }
 
@@ -213,6 +277,72 @@ public partial class NumberAnnotation : Annotation
             StartPoint.Y - Radius,
             StartPoint.X + Radius,
             StartPoint.Y + Radius);
+    }
+
+    public bool TryGetArrowTailOutline(
+        out SKPoint shaftStartLeft,
+        out SKPoint shaftEndLeft,
+        out SKPoint wingLeft,
+        out SKPoint tailTip,
+        out SKPoint wingRight,
+        out SKPoint shaftEndRight,
+        out SKPoint shaftStartRight)
+    {
+        shaftStartLeft = default;
+        shaftEndLeft = default;
+        wingLeft = default;
+        tailTip = default;
+        wingRight = default;
+        shaftEndRight = default;
+        shaftStartRight = default;
+
+        float radius = Radius;
+        if (radius <= GeometryEpsilon)
+        {
+            return false;
+        }
+
+        tailTip = GetTailHandlePoint();
+        var center = StartPoint;
+
+        float directionX = tailTip.X - center.X;
+        float directionY = tailTip.Y - center.Y;
+        float directionLength = MathF.Sqrt(directionX * directionX + directionY * directionY);
+        if (directionLength <= radius + GeometryEpsilon)
+        {
+            return false;
+        }
+
+        var arrowPoints = ArrowAnnotation.ComputeArrowPoints(
+            center.X,
+            center.Y,
+            tailTip.X,
+            tailTip.Y,
+            StrokeWidth * ArrowAnnotation.ArrowHeadWidthMultiplier);
+        if (arrowPoints is not { } points)
+        {
+            return false;
+        }
+
+        shaftEndLeft = points.ShaftEndLeft;
+        shaftEndRight = points.ShaftEndRight;
+        wingLeft = points.WingLeft;
+        wingRight = points.WingRight;
+
+        float shaftHalfWidth = Distance(shaftEndLeft, shaftEndRight) / 2f;
+        float normalizedDirectionX = directionX / directionLength;
+        float normalizedDirectionY = directionY / directionLength;
+        var perpendicular = new SKPoint(-normalizedDirectionY, normalizedDirectionX);
+
+        var shaftBaseLeft = new SKPoint(
+            center.X + perpendicular.X * shaftHalfWidth,
+            center.Y + perpendicular.Y * shaftHalfWidth);
+        var shaftBaseRight = new SKPoint(
+            center.X - perpendicular.X * shaftHalfWidth,
+            center.Y - perpendicular.Y * shaftHalfWidth);
+
+        return TryGetCircleSegmentExitPoint(center, radius, shaftBaseLeft, tailTip, out shaftStartLeft) &&
+               TryGetCircleSegmentExitPoint(center, radius, shaftBaseRight, tailTip, out shaftStartRight);
     }
 
     private static bool TryGetCircleSegmentExitPoint(SKPoint center, float radius, SKPoint start, SKPoint end, out SKPoint intersection)
@@ -262,10 +392,37 @@ public partial class NumberAnnotation : Annotation
         return !(hasNegative && hasPositive);
     }
 
+    private static bool PointInPolygon(SKPoint point, IReadOnlyList<SKPoint> polygon)
+    {
+        bool inside = false;
+
+        for (int i = 0, j = polygon.Count - 1; i < polygon.Count; j = i++)
+        {
+            var current = polygon[i];
+            var previous = polygon[j];
+            bool intersects = ((current.Y > point.Y) != (previous.Y > point.Y)) &&
+                              (point.X < ((previous.X - current.X) * (point.Y - current.Y) / ((previous.Y - current.Y) + GeometryEpsilon)) + current.X);
+
+            if (intersects)
+            {
+                inside = !inside;
+            }
+        }
+
+        return inside;
+    }
+
     private static float Sign(SKPoint p1, SKPoint p2, SKPoint p3)
     {
         return (p1.X - p3.X) * (p2.Y - p3.Y) -
                (p2.X - p3.X) * (p1.Y - p3.Y);
+    }
+
+    private static float Distance(SKPoint a, SKPoint b)
+    {
+        float dx = a.X - b.X;
+        float dy = a.Y - b.Y;
+        return MathF.Sqrt(dx * dx + dy * dy);
     }
 
     private static float DistanceToSegment(SKPoint point, SKPoint start, SKPoint end)
@@ -288,5 +445,18 @@ public partial class NumberAnnotation : Annotation
         float deltaY = point.Y - projectionY;
 
         return MathF.Sqrt(deltaX * deltaX + deltaY * deltaY);
+    }
+
+    private static SKRect UnionPoints(SKRect initialBounds, params SKPoint[] points)
+    {
+        var result = initialBounds;
+
+        foreach (var point in points)
+        {
+            var pointBounds = new SKRect(point.X, point.Y, point.X, point.Y);
+            result = SKRect.Union(result, pointBounds);
+        }
+
+        return result;
     }
 }

--- a/src/ShareX.ImageEditor/Presentation/Controllers/EditorSelectionController.cs
+++ b/src/ShareX.ImageEditor/Presentation/Controllers/EditorSelectionController.cs
@@ -457,7 +457,7 @@ public class EditorSelectionController
         if (_selectedShape is StepControl stepControl && stepControl.Annotation is NumberAnnotation number && handleTag == "StepTail")
         {
             number.SetTailPoint(new SKPoint((float)currentPoint.X, (float)currentPoint.Y));
-            stepControl.InvalidateVisual();
+            AnnotationVisualFactory.UpdateVisualControl(stepControl, number);
             _startPoint = currentPoint;
             UpdateSelectionHandles();
             return;
@@ -1913,6 +1913,11 @@ public class EditorSelectionController
         if (control is SpeechBalloonControl balloonControl && balloonControl.Annotation is SpeechBalloonAnnotation balloonAnnotation)
         {
             return ToRect(balloonAnnotation.GetBounds());
+        }
+
+        if (control is StepControl stepControl && stepControl.Annotation is NumberAnnotation numberAnnotation)
+        {
+            return ToRect(numberAnnotation.GetInteractionBounds());
         }
 
         if (control.Tag is Annotation annotation)

--- a/src/ShareX.ImageEditor/Presentation/Controls/StepControl.cs
+++ b/src/ShareX.ImageEditor/Presentation/Controls/StepControl.cs
@@ -37,11 +37,13 @@ public class StepControl : Control
             return;
         }
 
-        var annotationBounds = Annotation.GetBounds();
-        var width = Math.Max(annotationBounds.Width, 2);
-        var height = Math.Max(annotationBounds.Height, 2);
-
-        var bodyGeometry = new EllipseGeometry(new Rect(0, 0, width, height));
+        var visualBounds = Annotation.GetInteractionBounds();
+        var bodyBounds = Annotation.GetBounds();
+        var bodyGeometry = new EllipseGeometry(new Rect(
+            bodyBounds.Left - visualBounds.Left,
+            bodyBounds.Top - visualBounds.Top,
+            Math.Max(bodyBounds.Width, 2),
+            Math.Max(bodyBounds.Height, 2)));
         var tailGeometry = CreateTailGeometry(Annotation);
         Geometry geometry = tailGeometry != null
             ? new CombinedGeometry(GeometryCombineMode.Union, bodyGeometry, tailGeometry)
@@ -62,8 +64,8 @@ public class StepControl : Control
             Annotation.FontSize * 0.6,
             new SolidColorBrush(Color.Parse(Annotation.TextColor)));
 
-        var textX = (width - formattedText.Width) / 2;
-        var textY = (height - formattedText.Height) / 2;
+        var textX = bodyBounds.Left - visualBounds.Left + ((bodyBounds.Width - formattedText.Width) / 2);
+        var textY = bodyBounds.Top - visualBounds.Top + ((bodyBounds.Height - formattedText.Height) / 2);
         context.DrawText(formattedText, new Point(textX, textY));
     }
 
@@ -97,25 +99,29 @@ public class StepControl : Control
 
     private static Geometry? CreateArrowTailGeometry(NumberAnnotation annotation)
     {
-        var tailPoint = annotation.GetDefaultTailHandlePoint();
+        if (!annotation.TryGetArrowTailOutline(
+            out var shaftStartLeft,
+            out var shaftEndLeft,
+            out var wingLeft,
+            out var tailTip,
+            out var wingRight,
+            out var shaftEndRight,
+            out var shaftStartRight))
+        {
+            return null;
+        }
 
         var geometry = new StreamGeometry();
         using (var ctx = geometry.Open())
         {
-            var pts = ArrowAnnotation.ComputeArrowPoints(
-                annotation.StartPoint.X, annotation.StartPoint.Y,
-                tailPoint.X, tailPoint.Y,
-                annotation.StrokeWidth * ArrowAnnotation.ArrowHeadWidthMultiplier);
-
-            if (pts is { } p)
-            {
-                ctx.BeginFigure(ToRenderPoint(annotation, p.ShaftEndLeft), true);
-                ctx.LineTo(ToRenderPoint(annotation, p.WingLeft));
-                ctx.LineTo(ToRenderPoint(annotation, tailPoint));
-                ctx.LineTo(ToRenderPoint(annotation, p.WingRight));
-                ctx.LineTo(ToRenderPoint(annotation, p.ShaftEndRight));
-                ctx.EndFigure(true);
-            }
+            ctx.BeginFigure(ToRenderPoint(annotation, shaftStartLeft), true);
+            ctx.LineTo(ToRenderPoint(annotation, shaftEndLeft));
+            ctx.LineTo(ToRenderPoint(annotation, wingLeft));
+            ctx.LineTo(ToRenderPoint(annotation, tailTip));
+            ctx.LineTo(ToRenderPoint(annotation, wingRight));
+            ctx.LineTo(ToRenderPoint(annotation, shaftEndRight));
+            ctx.LineTo(ToRenderPoint(annotation, shaftStartRight));
+            ctx.EndFigure(true);
         }
 
         return geometry;
@@ -123,7 +129,7 @@ public class StepControl : Control
 
     private static Point ToRenderPoint(NumberAnnotation annotation, SKPoint point)
     {
-        var bounds = annotation.GetBounds();
+        var bounds = annotation.GetInteractionBounds();
         return new Point(point.X - bounds.Left, point.Y - bounds.Top);
     }
 }

--- a/src/ShareX.ImageEditor/Presentation/Rendering/AnnotationVisuals/AnnotationVisualFactory.cs
+++ b/src/ShareX.ImageEditor/Presentation/Rendering/AnnotationVisuals/AnnotationVisualFactory.cs
@@ -112,7 +112,7 @@ public static class AnnotationVisualFactory
 
             case NumberAnnotation number when control is StepControl stepControl:
                 stepControl.Annotation = number;
-                ApplyBoundsControl(stepControl, number.GetBounds(), ensureMinimumSize);
+                ApplyBoundsControl(stepControl, number.GetInteractionBounds(), ensureMinimumSize);
                 stepControl.InvalidateVisual();
                 break;
 


### PR DESCRIPTION
This pull request enhances the rendering, hit testing, and interaction logic for step number annotations with arrow tails in the image editor. The changes introduce more accurate geometric calculations for arrow-shaped tails, ensure consistent visual updates, and improve selection and hit detection for both triangle and arrow tail styles.

Key changes include:

### Geometry and Hit Testing Improvements

* Added `TryGetArrowTailOutline` to `NumberAnnotation`, providing precise calculation of all relevant points for an arrow tail, enabling more accurate rendering, hit testing, and bounds calculation for arrow-style tails.
* Updated `HitTest`, `IsTailVisible`, and `GetInteractionBounds` in `NumberAnnotation` to use the new arrow outline logic when the tail style is set to arrow, improving accuracy for user interactions and selection. [[1]](diffhunk://#diff-b5c5c60ef76924642ddd10a367a2eadfbfae58bd2743b6701b9a16f83c0127daL112-R147) [[2]](diffhunk://#diff-b5c5c60ef76924642ddd10a367a2eadfbfae58bd2743b6701b9a16f83c0127daL194-R269)
* Added general-purpose geometry helpers: `PointInPolygon`, `Distance`, and `UnionPoints` for improved geometric calculations and code reuse. [[1]](diffhunk://#diff-b5c5c60ef76924642ddd10a367a2eadfbfae58bd2743b6701b9a16f83c0127daR400-R432) [[2]](diffhunk://#diff-b5c5c60ef76924642ddd10a367a2eadfbfae58bd2743b6701b9a16f83c0127daR454-R466)

### Visual and Rendering Updates

* Modified `StepControl.Render` to use `GetInteractionBounds` for layout, ensuring that the drawn geometry and text are properly aligned and sized regardless of tail style. The arrow tail geometry is now constructed from the full outline, ensuring correct visual representation. [[1]](diffhunk://#diff-42d2e78e7715c3ee666395bf62987e4fa4c0cd3af49f90fbbc6fac69359ed794L40-R46) [[2]](diffhunk://#diff-42d2e78e7715c3ee666395bf62987e4fa4c0cd3af49f90fbbc6fac69359ed794L65-R68) [[3]](diffhunk://#diff-42d2e78e7715c3ee666395bf62987e4fa4c0cd3af49f90fbbc6fac69359ed794L100-R132)
* Updated `AnnotationVisualFactory.UpdateVisualControl` to use `GetInteractionBounds` for step controls, ensuring the control bounds match the rendered annotation including the tail.

### Interaction and Selection Consistency

* Updated selection and resizing logic in `EditorSelectionController` to use `AnnotationVisualFactory.UpdateVisualControl` for number annotations, ensuring visuals are refreshed after tail movement. Also updated selection rectangle calculation to use the full interaction bounds for step controls. [[1]](diffhunk://#diff-ab0dd0a6b393af4718e02b5a9b2e80c99a9ec831791d0da0b7402c6c732f1279L460-R460) [[2]](diffhunk://#diff-ab0dd0a6b393af4718e02b5a9b2e80c99a9ec831791d0da0b7402c6c732f1279R1918-R1922)